### PR TITLE
Fix some minor bugs according to importing some functions from ShockwaveProperties

### DIFF
--- a/notebooks/visualize_euler.jl
+++ b/notebooks/visualize_euler.jl
@@ -81,7 +81,7 @@ function plotframe(frame, data, bounds)
 		plot(xs, data.u[i, :, frame], legend=false, ylabel=ylabels[i], xticks=(i==3), ylims=bounds[i], dpi=600) 
 		for i=1:3]
 	p_data = map(eachcol(data.u[:, :, frame])) do u
-		c = ConservedState(u[1], u[2:end-1], u[end])
+		c = ConservedProps(u[1], u[2:end-1], u[end])
 		return uconvert(u"kPa", pressure(c; gas=DRY_AIR))
 	end
 	pressure_plot=plot(xs, p_data, ylabel=L"P", legend=false)
@@ -134,7 +134,7 @@ function plotframe_signal_speeds(frame, data, bounds; gas=DRY_AIR)
 		[aL aR]
 	end
 	M1 = map(eachcol(@view u_k[:, 2:end])) do u
-		s = ConservedState(u[1], u[2:end-1], u[end])
+		s = ConservedProps(u[1], u[2:end-1], u[end])
 		return ustrip(u"m/s", speed_of_sound(s; gas=DRY_AIR))
 	end
 	labels=[L"a_L", L"a_R"]

--- a/scripts/1d_plots.jl
+++ b/scripts/1d_plots.jl
@@ -107,8 +107,8 @@ end
 # SHOCK AT X = 0
 # SUPERSONIC FLOW IMPACTS STATIC ATMOSPHERIC AIR
 
-uL_1 = ConservedState(PrimitiveState(1.225, [1.5], 300.0); gas = DRY_AIR)
-uR_1 = ConservedState(PrimitiveState(1.225, [0.0], 350.0); gas = DRY_AIR)
+uL_1 = ConservedProps(PrimitiveProps(1.225, [1.5], 300.0); gas = DRY_AIR)
+uR_1 = ConservedProps(PrimitiveProps(1.225, [0.0], 350.0); gas = DRY_AIR)
 
 u1(x) = state_to_vector(x < 0 ? uL_1 : uR_1)
 left_bc_1 = SupersonicInflow(uL_1)
@@ -136,9 +136,9 @@ simulate_euler_1d(
 # SHOCKS AT X = -50 and X = 50
 # SUPERSONIC INFLOW ON BOTH SIDES
 
-uL_2 = ConservedState(PrimitiveState(1.225, [2.0], 300.0); gas = DRY_AIR)
-uM_2 = ConservedState(PrimitiveState(1.225, [0.0], 350.0); gas = DRY_AIR)
-uR_2 = ConservedState(PrimitiveState(1.225, [-2.0], 300.0); gas = DRY_AIR)
+uL_2 = ConservedProps(PrimitiveProps(1.225, [2.0], 300.0); gas = DRY_AIR)
+uM_2 = ConservedProps(PrimitiveProps(1.225, [0.0], 350.0); gas = DRY_AIR)
+uR_2 = ConservedProps(PrimitiveProps(1.225, [-2.0], 300.0); gas = DRY_AIR)
 
 interface_signal_speeds(state_to_vector(uL_2), state_to_vector(uM_2), 1; gas=DRY_AIR)
 Euler2D.ϕ_hll(state_to_vector(uL_2), state_to_vector(uM_2), 1; gas=DRY_AIR)

--- a/src/fvm.jl
+++ b/src/fvm.jl
@@ -79,7 +79,7 @@ Fields
  - `prescribed_state`: The state prescribed outside the boundary.
 """
 struct FixedPhantomOutside <: PhantomEdge{1}
-    prescribed_state::ConservedState
+    prescribed_state::ConservedProps
 end
 
 function phantom_cell(
@@ -103,12 +103,12 @@ Fields
  Must have a velocity that points _into_ the domain.
 """
 struct SupersonicInflow <: PhantomEdge{1}
-    prescribed_state::ConservedState
+    prescribed_state::ConservedProps
 end
 
-function SupersonicInflow(s::PrimitiveState; gas::CaloricallyPerfectGas)
+function SupersonicInflow(s::PrimitiveProps; gas::CaloricallyPerfectGas)
     @assert all(>(1.0), s.M) "Cannot construct a supersonic inflow boundary with M_∞ ≤ 1.0!"
-    return SupersonicInflow(ConservedState(s; gas = gas))
+    return SupersonicInflow(ConservedProps(s; gas = gas))
 end
 
 function phantom_cell(


### PR DESCRIPTION
Here I change every States to Props according to the new exports of [ShockwaveProperties.jl](https://github.com/STCE-at-RWTH/ShockwaveProperties.jl). However the scripts `scripts/1d_plots.jl` still need a bit of fixing.

There is this function in `scripts/1d_plots.jl`
`internal_energy_density` which is called by `pressure_u` in `interface_signal_speeds` in line 143 and there is no export of this function in ShockwaveProperties.jl
Could you explain whether it should be `static_internal_energy_density` or `total_internal_energy_density` and briefly why? (my personal curiosity)